### PR TITLE
Idempotent mkdirp

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Usage
 ```shell
-$ npm i -P colbydauph/funk-fs
+$ npm i -P colbydauph/funk-fs#0.5.0
 ```
 
 ```javascript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "funk-fs",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -976,9 +976,9 @@
       "dev": true
     },
     "has": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.2.tgz",
-      "integrity": "sha512-D5/WxwX+SrGfs/fiQn34RAoIZkCLJBDEfBWS1kmTI6G/1mtjhxTBiIiJi8EsKhwaQqKqj7lpKOi3i69tg3P+OQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funk-fs",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "engines": {
     "node": ">= 8.2"
   },
@@ -35,9 +35,9 @@
   },
   "nyc": {
     "statements": 65,
-    "branches": 80,
+    "branches": 85,
     "functions": 30,
-    "lines": 90,
+    "lines": 95,
     "reporter": [
       "html",
       "text-summary"

--- a/src/extra.js
+++ b/src/extra.js
@@ -31,30 +31,6 @@ const isDirSync = R.curry((filepath, fs) => statSync(filepath, fs).isDirectory()
 const isFile = R.curry(async (filepath, fs) => (await stat(filepath, fs)).isFile());
 const isFileSync = R.curry((filepath, fs) => statSync(filepath, fs).isFile());
 
-// string -> fs -> undefined
-const mkdirp = R.curry(async (path, fs) => {
-  try {
-    return await mkdir(path, fs);
-  } catch (err) {
-    if (err.code !== 'ENOENT') throw err;
-    // recursively make parent dir
-    await mkdirp(dirname(path), fs);
-    // retry original
-    return await mkdirp(path, fs);
-  }
-});
-const mkdirpSync = R.curry((path, fs) => {
-  try {
-    return mkdirSync(path, fs);
-  } catch (err) {
-    if (err.code !== 'ENOENT') throw err;
-    // recursively make parent dir
-    mkdirpSync(dirname(path), fs);
-    // retry original
-    return mkdirpSync(path, fs);
-  }
-});
-
 // string -> fs -> [string]
 const readDirDeep = R.curry(async (dirPath, fs) => {
   const files = await readDir(dirPath, fs);
@@ -152,6 +128,33 @@ const writeTree = R.curry(async (root, tree, fs) => {
       : writeFile(value, absFilepath, fs);
 
   }, R.toPairs(tree));
+});
+
+
+// string -> fs -> undefined
+const mkdirp = R.curry(async (path, fs) => {
+  if (await dirExists(path, fs)) return;
+  try {
+    return await mkdir(path, fs);
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+    // recursively make parent dir
+    await mkdirp(dirname(path), fs);
+    // retry original
+    return await mkdirp(path, fs);
+  }
+});
+const mkdirpSync = R.curry((path, fs) => {
+  if (dirExistsSync(path, fs)) return;
+  try {
+    return mkdirSync(path, fs);
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+    // recursively make parent dir
+    mkdirpSync(dirname(path), fs);
+    // retry original
+    return mkdirpSync(path, fs);
+  }
 });
 
 // copy file or directory (recursive)

--- a/src/extra.js
+++ b/src/extra.js
@@ -137,6 +137,7 @@ const mkdirp = R.curry(async (path, fs) => {
   try {
     return await mkdir(path, fs);
   } catch (err) {
+    if (err.code === 'EEXIST') return;
     if (err.code !== 'ENOENT') throw err;
     // recursively make parent dir
     await mkdirp(dirname(path), fs);
@@ -145,10 +146,10 @@ const mkdirp = R.curry(async (path, fs) => {
   }
 });
 const mkdirpSync = R.curry((path, fs) => {
-  if (dirExistsSync(path, fs)) return;
   try {
     return mkdirSync(path, fs);
   } catch (err) {
+    if (err.code === 'EEXIST') return;
     if (err.code !== 'ENOENT') throw err;
     // recursively make parent dir
     mkdirpSync(dirname(path), fs);

--- a/src/extra.js
+++ b/src/extra.js
@@ -133,7 +133,6 @@ const writeTree = R.curry(async (root, tree, fs) => {
 
 // string -> fs -> undefined
 const mkdirp = R.curry(async (path, fs) => {
-  if (await dirExists(path, fs)) return;
   try {
     return await mkdir(path, fs);
   } catch (err) {

--- a/src/tests/extra.test.js
+++ b/src/tests/extra.test.js
@@ -349,7 +349,11 @@ describe('extra functions', () => {
       expect(dirExistsSync('/sync/other/test-dir', fs)).to.eql(true);
     });
     
-    it('should not throw if the root dir exists?');
+    it('should not throw if the root dir exists', async () => {
+      await mkdirp('/test-root', fs);
+      await expect(mkdirp('/test-root', fs)).to.not.be.rejectedWith(Error);
+      expect(() => mkdirpSync('/test-root', fs)).to.not.throw(Error);
+    });
     
   });
   


### PR DESCRIPTION
`mkdirp` and `mkdirpSync` no longer throw if their root dir already exists